### PR TITLE
Mudança na estrutura dos arquivos dos hinos

### DIFF
--- a/pages/[hymnBook]/[slug].tsx
+++ b/pages/[hymnBook]/[slug].tsx
@@ -31,7 +31,7 @@ type PageProps = { content: Hymn; hymnBooks: HymnBook[]; hymnBook: string };
 
 export default function HymnView(props: AppProps & PageProps) {
   const {
-    content: { number, title, subtitle, stanzas, chorus },
+    content: { number, title, subtitle, lyrics },
   } = props;
 
   useHymnBooksSave(props.hymnBooks);
@@ -50,9 +50,9 @@ export default function HymnView(props: AppProps & PageProps) {
     localStorage.setItem('fontSize', fontSize);
   }, [fontSize]);
 
-  const chorusComponent = chorus && (
+  const Chorus = ({ text }: { text: string }) => (
     <Text size={fontSize} mt={16} pl={40} italic>
-      <HymnTextWithVariations>{chorus}</HymnTextWithVariations>
+      <HymnTextWithVariations>{text}</HymnTextWithVariations>
     </Text>
   );
 
@@ -97,18 +97,19 @@ export default function HymnView(props: AppProps & PageProps) {
           ]}
         />
       </Box>
-      {!stanzas.length && <Box mt={16}>{chorusComponent}</Box>}
-      {stanzas.map((stanza, index) => (
-        <Fragment key={stanza.number}>
-          {/* <Text>{stanza.number}.</Text> */}
-          <Text size={fontSize} mt={16} pl={20} style={{ position: 'relative' }}>
-            <span style={{ position: 'absolute', left: 0 }}>{stanza.number}.</span>
-            <HymnTextWithVariations>{stanza.text}</HymnTextWithVariations>
-          </Text>
+      {lyrics.map((lyric) => {
+        if (lyric.type === 'chorus') return <Chorus text={lyric.text} />;
 
-          {index === 0 && chorus && chorusComponent}
-        </Fragment>
-      ))}
+        return (
+          <Fragment key={lyric.number}>
+            {/* <Text>{stanza.number}.</Text> */}
+            <Text size={fontSize} mt={16} pl={20} style={{ position: 'relative' }}>
+              <span style={{ position: 'absolute', left: 0 }}>{lyric.number}.</span>
+              <HymnTextWithVariations>{lyric.text}</HymnTextWithVariations>
+            </Text>
+          </Fragment>
+        );
+      })}
 
       {hymnBook?.slug === 'hinos-e-canticos' ? (
         <>

--- a/schemas/hymn.ts
+++ b/schemas/hymn.ts
@@ -4,13 +4,19 @@ export const hymnSchema = z.object({
   number: z.number().or(z.string()),
   title: z.string(),
   subtitle: z.string().optional(),
-  stanzas: z.array(
-    z.object({
-      number: z.number(),
-      text: z.string(),
-    })
+  lyrics: z.array(
+    z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('stanza'),
+        number: z.number(),
+        text: z.string(),
+      }),
+      z.object({
+        type: z.literal('chorus'),
+        text: z.string(),
+      }),
+    ])
   ),
-  chorus: z.string().optional(),
 });
 
 export type Hymn = z.infer<typeof hymnSchema>;


### PR DESCRIPTION
# Implementação da Issue #46  

A estrutura dos hinos foi refatorada para suportar múltiplos estribilhos, permitindo que sejam organizados em uma ordem personalizada. O novo esquema está definido da seguinte forma:  

```ts
export const hymnSchema = z.object({
  number: z.number().or(z.string()),
  title: z.string(),
  subtitle: z.string().optional(),
  lyrics: z.array(
    z.discriminatedUnion('type', [
      z.object({
        type: z.literal('stanza'),
        number: z.number(),
        text: z.string(),
      }),
      z.object({
        type: z.literal('chorus'),
        text: z.string(),
      }),
    ])
  ),
});
```  

O campo `lyrics` foi introduzido para substituir os antigos campos `stanzas` e `chorus`, agrupando todas as estrofes e estribilhos em um único array que respeita a ordem definida. A exibição dos hinos foi ajustada para renderizar cada elemento (estrofe ou estribilho) conforme essa sequência.  

Os hinos existentes foram migrados para o novo formato através de um script e enviados para o firebase. Nesse processo, o campo `chorus` foi movido para a segunda posição do array `lyrics`.  
