### PR TITLE
Adicionando nova cli para hinos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ cert.json
 **/public/worker-*.js
 **/public/worker-*.js.map
 supabase/.temp/
+
+# internal scripts
+.release_data

--- a/cli/hymns/cmds/commit-release.ts
+++ b/cli/hymns/cmds/commit-release.ts
@@ -1,0 +1,99 @@
+import path from 'node:path';
+
+import { CommandModule } from 'yargs';
+import { $, ProcessOutput, chalk, fs as fszx, question, useBash, which } from 'zx';
+
+import { ReleaseData } from 'types/cli/ReleaseData';
+import { logger } from '../logger';
+
+useBash();
+
+const rootPath = path.resolve(__dirname, '..', '..', '..');
+
+const RELEASE_DATA_FILE_NAME = '.release_data';
+
+async function Command() {
+  const existsReleaseFile = await fszx.pathExists(path.resolve(rootPath, RELEASE_DATA_FILE_NAME));
+
+  if (!existsReleaseFile) {
+    logger.error("Release file doesn't exists. Please, create one before commiting");
+
+    return process.exit(0);
+  }
+
+  const releaseData = await (async () => {
+    if (!existsReleaseFile) return { updates: [] };
+
+    return (await fszx.readJSON(path.resolve(rootPath, RELEASE_DATA_FILE_NAME), {
+      encoding: 'utf-8',
+    })) as ReleaseData;
+  })();
+
+  if (releaseData.updates.length === 0) {
+    logger.error("Release file doesn't have any updates. Please, add one before commiting");
+
+    return process.exit(0);
+  }
+
+  const releaseTitle = new Date().toISOString().split('T')[0];
+
+  const releaseUpdates = releaseData.updates
+    .map((update) => `- ${update.hymn}: ${update.message}`)
+    .join('\n');
+
+  const releaseBody = `# Ajustes de conteúdo\n${releaseUpdates}`;
+
+  logger.info('Release title:', releaseTitle);
+  logger.info('Release body:');
+  console.log(releaseBody, '\n');
+
+  const confirmation = await question(
+    `Are you sure you want to commit release ${chalk.blue(releaseTitle)}? (y/n) `
+  );
+
+  if (confirmation !== 'y') {
+    logger.info('Aborting...');
+
+    return;
+  }
+
+  const hasGithubCli = await which('gh', { nothrow: true });
+
+  if (hasGithubCli) {
+    logger.info('Generating release in Github using gh...');
+
+    try {
+      const releaseLink = (
+        await $`echo ${releaseBody} | gh release create ${releaseTitle} --title="${releaseTitle}" -F -`.quiet()
+      ).text();
+      logger.info('Release created successfully!');
+      logger.info('Link to release:');
+      logger.blue(releaseLink);
+    } catch (err) {
+      const error = err as ProcessOutput;
+
+      logger.error('Error while generating release in Github:', '\n');
+      logger.red(error.stderr);
+    }
+
+    return;
+  }
+
+  logger.info(
+    "You don't have the Github CLI installed. Use this link to generate release in Github:"
+  );
+
+  const createReleaseURL = new URL(`https://github.com/coisasdoalto/hinarios-web/releases/new`);
+
+  createReleaseURL.searchParams.set('title', releaseTitle);
+  createReleaseURL.searchParams.set('body', releaseBody);
+  createReleaseURL.searchParams.set('tag', releaseTitle);
+
+  logger.blue(createReleaseURL.toString());
+}
+
+export const CommitReleaseCommand: CommandModule = {
+  command: 'commit-release',
+  describe: 'Generate commit release',
+  handler: () => Command(),
+};

--- a/cli/hymns/cmds/index.ts
+++ b/cli/hymns/cmds/index.ts
@@ -1,0 +1,6 @@
+import { CommandModule } from 'yargs';
+
+import { CommitReleaseCommand } from './commit-release';
+import { UpdateHymnsCommand } from './update';
+
+export const commands: CommandModule[] = [UpdateHymnsCommand, CommitReleaseCommand];

--- a/cli/hymns/cmds/update.ts
+++ b/cli/hymns/cmds/update.ts
@@ -1,0 +1,123 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+import slugify from 'slugify';
+import { CommandModule } from 'yargs';
+import { z } from 'zod';
+import { fs as fszx } from 'zx';
+
+import getParsedData from 'data/getParsedData';
+import { hymnSchema } from 'schemas/hymn';
+import { ReleaseData } from 'types/cli/ReleaseData';
+
+import { logger } from '../logger';
+
+/**
+ * @example
+ *  "hc/1"
+ *  "he/1"
+ *  "ccs/1"
+ */
+const hymnArgRegex = /^(hc|he|ccs)\/(\d+)/;
+
+const argvSchema = z.object({
+  hymn: z
+    .string()
+    .regex(hymnArgRegex, 'Invalid hymn reference format')
+    .transform((hymn) => {
+      const [, book, number] = hymn.match(hymnArgRegex)!;
+
+      const hymnBookReference = book.toUpperCase(); // hc -> HC
+
+      const hymnBook = {
+        hc: 'hinos-e-canticos',
+        he: 'hinos-espirituais',
+        ccs: 'corinhos-e-canticos-de-salvacao',
+      }[book];
+
+      return {
+        reference: `${hymnBookReference} ${number}`, // HC 1
+        book: hymnBook,
+        number: Number(number),
+      };
+    }),
+  message: z.string().min(1, "Message can't be empty"),
+});
+
+const rootPath = path.resolve(__dirname, '..', '..', '..');
+
+const RELEASE_DATA_FILE_NAME = '.release_data';
+
+async function Command(argv: unknown) {
+  const update = argvSchema.parse(argv);
+
+  const alreadyExistsReleaseFile = await fszx.pathExists(
+    path.resolve(rootPath, RELEASE_DATA_FILE_NAME)
+  );
+
+  const currentReleaseData = await (async () => {
+    if (!alreadyExistsReleaseFile) return { updates: [] };
+
+    return (await fszx.readJSON(path.resolve(rootPath, RELEASE_DATA_FILE_NAME), {
+      encoding: 'utf-8',
+    })) as ReleaseData;
+  })();
+
+  const hymnDataFilePath = `${update.hymn.book}/${update.hymn.number}.json`;
+  const hymnData = await getParsedData({
+    filePath: hymnDataFilePath,
+    schema: hymnSchema,
+  });
+
+  const hymnFirstLyric = hymnData.lyrics[0].text.split('\n')[0].replaceAll('"', '');
+
+  const releaseHymnReference = `${update.hymn.reference} (${hymnFirstLyric})`;
+
+  const releaseHymnReferenceWithLinkToHinariosApp = `[${releaseHymnReference}](http://hinarios.app/${
+    update.hymn.book
+  }/${update.hymn.number}-${slugify(hymnData.title)})`;
+
+  const newReleaseData: ReleaseData = {
+    updates: [
+      ...currentReleaseData.updates,
+      {
+        hymn: releaseHymnReferenceWithLinkToHinariosApp,
+        message: update.message,
+      },
+    ],
+  };
+
+  const newReleaseFileContent = JSON.stringify(newReleaseData, null, 2);
+
+  await fs.writeFile(path.resolve(rootPath, RELEASE_DATA_FILE_NAME), newReleaseFileContent);
+
+  if (!alreadyExistsReleaseFile) {
+    logger.info('Release file created successfully');
+    return;
+  }
+
+  logger.info('Release file updated successfully');
+}
+
+export const UpdateHymnsCommand: CommandModule = {
+  command: 'update <hymnReference>',
+  describe: 'Update hymn and save changes in release file',
+  builder: (yargs) =>
+    yargs
+      .positional('hymnReference', {
+        type: 'string',
+        description: `Hymn reference.
+        Format: <hymn-book-alias>/<hymn-number>.
+        Example: hc/1
+        Hymn books alias: 
+          - hc: Hino e cânticos
+          - he: Hinos espirituais
+          - ccs: Corinhos e cânticos de salvação`,
+        alias: 'hymn',
+      })
+      .option('message', {
+        description: 'Update message. This is will be included in release',
+        alias: 'm',
+      }),
+  handler: (argv) => Command(argv),
+};

--- a/cli/hymns/error-handler.ts
+++ b/cli/hymns/error-handler.ts
@@ -1,0 +1,27 @@
+import yargs from 'yargs';
+import { ZodError } from 'zod';
+
+import { logger } from './logger';
+
+type YargsFailHandlerArgs = Parameters<yargs.Argv<{}>['fail']>[0];
+
+export function yargsErrorHandler(...args: Parameters<YargsFailHandlerArgs>) {
+  const [msg, err, yargs] = args;
+
+  if (err instanceof ZodError) {
+    const [command] = process.argv.slice(2);
+
+    logger.error(err.issues.map((issue) => issue.message).join('\n'), '\n');
+
+    console.log(yargs.help(command));
+
+    return process.exit(0);
+  }
+
+  if (err) throw err;
+
+  logger.error(msg, '\n');
+  console.log(yargs.help());
+
+  return process.exit(1);
+}

--- a/cli/hymns/index.ts
+++ b/cli/hymns/index.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+import { commands } from './cmds/';
+import { yargsErrorHandler } from './error-handler';
+
+const cli = yargs(hideBin(process.argv))
+  .scriptName('hymns')
+  .strict()
+  .demandCommand(1, 'You need at least one command')
+  .recommendCommands()
+  .strict()
+  .locale('en')
+  .fail(yargsErrorHandler);
+
+for (const command of commands) {
+  cli.command(command);
+}
+
+cli.parse();

--- a/cli/hymns/logger.ts
+++ b/cli/hymns/logger.ts
@@ -1,0 +1,8 @@
+import { chalk } from 'zx';
+
+export const logger = {
+  info: (...args: unknown[]) => console.log(chalk.blue('info:'), ...args),
+  error: (...args: unknown[]) => console.error(chalk.red('error:'), ...args),
+  blue: (...args: unknown[]) => console.log(chalk.blue(...args)),
+  red: (...args: unknown[]) => console.log(chalk.red(...args)),
+};

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "data:download": "yarn scripts:run scripts/downloadData.ts",
     "generate:index": "yarn scripts:run scripts/generateHymnsIndex.ts",
     "generate:searchIndex": "yarn scripts:run scripts/generateSearchIndex.ts",
-    "generate:pathsForPrecache": "yarn scripts:run scripts/generatePathsForPrecache.ts"
+    "generate:pathsForPrecache": "yarn scripts:run scripts/generatePathsForPrecache.ts",
+    "hymns": "tsx cli/hymns/index.ts"
   },
   "dependencies": {
     "@emotion/react": "^11.10.4",
@@ -60,8 +61,10 @@
     "slugify": "^1.6.5",
     "typesaurus": "^10.3.0",
     "wretch": "^2.4.1",
+    "yargs": "^17.7.2",
     "zod": "^3.20.6",
-    "zod-fetch": "^0.1.0"
+    "zod-fetch": "^0.1.0",
+    "zx": "^8.2.4"
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",

--- a/types/cli/ReleaseData.ts
+++ b/types/cli/ReleaseData.ts
@@ -1,0 +1,6 @@
+export type ReleaseData = {
+  updates: {
+    hymn: string;
+    message: string;
+  }[];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3875,6 +3875,14 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
+"@types/fs-extra@>=11":
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-11.0.4.tgz#e16a863bb8843fba8c5004362b5a73e17becca45"
+  integrity sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==
+  dependencies:
+    "@types/jsonfile" "*"
+    "@types/node" "*"
+
 "@types/glob@*", "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -3954,6 +3962,13 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
+"@types/jsonfile@*":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@types/jsonfile/-/jsonfile-6.1.4.tgz#614afec1a1164e7d670b4a7ad64df3e7beb7b702"
+  integrity sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==
+  dependencies:
+    "@types/node" "*"
+
 "@types/jsonwebtoken@^9.0.0":
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/@types/jsonwebtoken/-/jsonwebtoken-9.0.1.tgz#29b1369c4774200d6d6f63135bf3d1ba3ef997a4"
@@ -4005,6 +4020,13 @@
   version "18.13.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.13.0.tgz#0400d1e6ce87e9d3032c19eb6c58205b0d3f7850"
   integrity sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==
+
+"@types/node@>=20":
+  version "22.10.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.1.tgz#41ffeee127b8975a05f8c4f83fb89bcb2987d766"
+  integrity sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==
+  dependencies:
+    undici-types "~6.20.0"
 
 "@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0":
   version "16.11.45"
@@ -14826,6 +14848,11 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
+undici-types@~6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
+  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+
 undici@5.28.3:
   version "5.28.3"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.28.3.tgz#a731e0eff2c3fcfd41c1169a869062be222d1e5b"
@@ -15756,3 +15783,11 @@ zwitch@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"
   integrity sha512-V50KMwwzqJV0NpZIZFwfOD5/lyny3WlSzRiXgA0G7VUnRlqttta1L6UQIHzd6EuBY/cHGfwTIck7w1yH6Q5zUw==
+
+zx@^8.2.4:
+  version "8.2.4"
+  resolved "https://registry.yarnpkg.com/zx/-/zx-8.2.4.tgz#28bc6a5c37d623b63a3a1c40198e0aaf9d2d136a"
+  integrity sha512-g9wVU+5+M+zVen/3IyAZfsZFmeqb6vDfjqFggakviz5uLK7OAejOirX+jeTOkyvAh/OYRlCgw+SdqzN7F61QVQ==
+  optionalDependencies:
+    "@types/fs-extra" ">=11"
+    "@types/node" ">=20"


### PR DESCRIPTION
Inclui uma nova CLI no projeto para lidar com as atualizações de hinos.
A CLI tem dois comandos
- `hymn update <hymnReference> -m <message>`: Esse comando vai criar um registro no arquivo `.release_data`
- `hymn commit-release`: Esse comando cria uma release no Github com base no `.release_data`