### PR TITLE
Correções de bugs reportados por feedbacks

### DIFF
--- a/components/Layout/Layout.tsx
+++ b/components/Layout/Layout.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Breadcrumbs,
   Burger,
   Button,
@@ -99,15 +100,17 @@ export default function AppShell({ children }: PropsWithChildren) {
         </Header>
       }
     >
-      <Container px={0} py={16}>
-        {children}
-      </Container>
+      <Box pb="6rem">
+        <Container px={0} py={16}>
+          {children}
+        </Container>
 
-      <Feedback />
+        <Feedback />
 
-      <PlayStoreButton />
+        <PlayStoreButton />
 
-      <NearbySongs />
+        <NearbySongs />
+      </Box>
     </MantineAppShell>
   );
 }

--- a/pages/[hymnBook]/[slug].tsx
+++ b/pages/[hymnBook]/[slug].tsx
@@ -154,7 +154,13 @@ export default function HymnView(props: AppProps & PageProps) {
           );
 
         return (
-          <Text key={lyric.number} size={fontSize} mt={16} pl={20} style={{ position: 'relative' }}>
+          <Text
+            key={`${lyric.number}.${title}`}
+            size={fontSize}
+            mt={16}
+            pl={20}
+            style={{ position: 'relative' }}
+          >
             <span style={{ position: 'absolute', left: 0 }}>{lyric.number}.</span>
             <HymnTextWithVariations>{lyric.text}</HymnTextWithVariations>
           </Text>


### PR DESCRIPTION
- Corrigido um problema em que, ao trocar de um hino com estrofes e estribilhos para um hino contendo apenas um estribilho, a primeira estrofe do hino anterior ainda permanecia visível
- Agora o botão de hinos próximos não fica sobrepondo a seção de feedbacks